### PR TITLE
add smart image tags to the booking experience

### DIFF
--- a/app/views/bookings/_booking_show_card.html.erb
+++ b/app/views/bookings/_booking_show_card.html.erb
@@ -1,7 +1,7 @@
 <% @bookings.sort_by(&:total_price).reverse.each do |booking| %>
 <!--<#% @bookings.each do |booking| %>-->
   <div class="card-trip mb-3">
-    <img src="https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/greece.jpg" />
+  <%= cl_image_tag booking.costume.photo.key, crop: :fill  %>
     <div class="card-trip-infos">
       <div>
         <h2><%=current_user.email%></h2>

--- a/app/views/costumes/_costume_show_card.html.erb
+++ b/app/views/costumes/_costume_show_card.html.erb
@@ -1,6 +1,6 @@
 
 <div class="card-trip">
-  <img src="https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/greece.jpg" />
+  <%= cl_image_tag costume.photo.key, crop: :fill  %>
   <div class="card-trip-infos">
     <div>
       <h2><%=costume.name%></h2>


### PR DESCRIPTION
![costume image on booking experience](https://user-images.githubusercontent.com/3223329/108844527-94f3c700-761f-11eb-8243-a5f76fc4e833.jpg)
![costume showbooking page with smart image tag](https://user-images.githubusercontent.com/3223329/108844532-9624f400-761f-11eb-8723-7aa32c6e7f8e.jpg)
![booking index with costume image](https://user-images.githubusercontent.com/3223329/108844538-97eeb780-761f-11eb-9774-d329636a029c.jpg)
![booking index page with costume images](https://user-images.githubusercontent.com/3223329/108844543-991fe480-761f-11eb-9b3e-b9ca486ec071.jpg)
Adds the actual image assigned to the costume instance to fill the cards on these pages.